### PR TITLE
Script for generating export keys and Onetime Secret links for a list of partners in Airtable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,34 @@ To deploy the static site, simply put the files on any web host. At MoveOn, we u
 
 The API is a Python 3.9 app designed to run on AWS Lambda. It can be used with any Mobilize America instance by changing the settings to point to your Mobilize America database (copy settings.py.template to settings.py). Each individual script (validate_key.py and export_rsvps.py) can also be run from the command line for testing.
 
-The scripts use AWS Secrets Manager, with a record called `ak-partner-rsvp` to store and call the `KEY_HASH_SECRET`, `MAX_AGE`, `EXTRA_WHERE`, and `DB_SCHEMA` variables unique to this deployment, and a `redshift-admin` configuration for database access.
+The scripts use AWS Secrets Manager, with a record called `ak-partner-rsvp` to store and call the variables below unique to this deployment, and a `redshift-admin` configuration for database access.
+
+* `KEY_HASH_SECRET` - This is the secret that is used for generating the export key.
+* `MAX_AGE` - The maximum allowed age of the export key.
+* `DB_SCHEMA` - The database schema that holds the Mobilize America tables.
+* `EVENT_CAMPAIGN_ID` - The numeric event campaign id in Mobilize America.
+* `EVENT_CAMPAIGN_END_DATE` - The last day of the event campaign. The export will include only records where the creation date is less than or equal to this value. For hosts, it is the `created_date` of the event in the `events` table; for attendees, it is the `created_date` of the RSVP in the `participations` table.
+* `UNSOURCED_SHARED_SCHEMA`, `UNSOURCED_SHARED_TABLE` - The database schema and table that holds the allocation of unsourced hosts/RSVPs to each partner source. This table can be empty, but it must exist. Expected columns:
+  * `event_campaign_id` - The numeric event campaign id in Mobilize America.
+  * `eventid_recordtype_userid` - A unique key containing the Mobilize America event id, the record type (`host` or `rsvp`), and the Mobilize America user id of the participant or host, separated by `.`. E.g., `123456.rsvp.24680`
+  * `shared_with_source` - The partner source code that this contact has been allocated to.
+* `CUSTOM_EVENT_IDS` - The list of Mobilize America event ids to use for the `custom_event_signups` export type.
 
 ### Deploy
 
 The API can be deployed using [Zappa](https://github.com/Miserlou/Zappa) with the provided zappa_settings.yml.template (copied to zappa_settings.yml).
 
 Each individual script has its own zappa_settings.py file, named zappa_settings_export.py and zappa_settings_validate.py. You'll most likely need to rename these to deploy.
+
+## Airtable/Onetime Secret integration script
+
+Given an Airtable base containing a list of partners, the included `gen_secrets_for_airtable.py` does the following:
+
+* Retrieves the list of partners from Airtable.
+* Generates an export key for each partner.
+* Creates a Onetime Secret link for the key, using the partner's official source code as the passphrase.
+* Writes the Onetime Secret link to back to Airtable.
+
+An automation can be set up in Airtable to send an email to the partner when the column containing their Onetime Secret link is filled in by the script.
+
+The script uses AWS Secrets Manager for the Airtable configuration (see the comments in the script for the list of expected keys) and [Parsons](https://www.parsonsproject.org/) for connecting to the Airtable and Onetime Secret APIs.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ Given an Airtable base containing a list of partners, the included `gen_secrets_
 An automation can be set up in Airtable to send an email to the partner when the column containing their Onetime Secret link is filled in by the script.
 
 The script uses AWS Secrets Manager for the Airtable configuration (see the comments in the script for the list of expected keys) and [Parsons](https://www.parsonsproject.org/) for connecting to the Airtable and Onetime Secret APIs.
+
+To avoid installing/loading the full Parsons dependencies, set the following environment variables before installing the requirements and running the script:
+
+```
+export PIP_NO_BINARY=parsons
+export PARSONS_LIMITED_DEPENDENCIES=true
+```
+
+See the [Parsons documentation](https://move-coop.github.io/parsons/html/stable/index.html#integrating-parsons) for details.

--- a/gen_secrets_for_airtable.py
+++ b/gen_secrets_for_airtable.py
@@ -1,0 +1,144 @@
+from datetime import datetime
+import hashlib
+import logging
+import os
+
+from pywell.secrets_manager import get_secret
+from pywell.entry_points import run_from_cli
+
+# MUST be above all parsons imports to avoid full parsons dependencies
+os.environ["PARSONS_SKIP_IMPORT_ALL"] = "1"
+
+from parsons.etl.table import Table  # noqa: E402
+from parsons.utilities.api_connector import APIConnector  # noqa: E402
+from parsons.airtable import Airtable  # noqa: E402
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    handlers=[logging.StreamHandler()],
+    format="%(levelname)s %(message)s",
+    level="INFO",
+)
+
+DESCRIPTION = "Generate export keys for partners listed in Airtable, create Onetime Secret url, and update Airtable with the url"
+ARG_DEFINITIONS = {}
+REQUIRED_ARGS = []
+
+"""
+This script gets a list of partners stored in Airtable, and for each one
+does the following:
+* Generates an export key for each partner.
+* Creates a Onetime Secret link for the key, using the partner's official
+    source code as the passphrase.
+* Writes the Onetime Secret link to back to Airtable.
+
+The following keys should be set in Secrets Manager:
+    AIRTABLE_BASE_KEY - The key/ID of the Airtable Base.
+    AIRTABLE_TABLE - The key/ID or name of the table in the Base.
+    AIRTABLE_PAT - The Airtable Personal Access Token.
+    AIRTABLE_COLUMN_ORG_NAME - The column that contains the partner's name.
+    AIRTABLE_COLUMN_SOURCE_CODE - The column that contains the official source code.
+    AIRTABLE_COLUMN_ADDITIONAL_CODES - The column that contains any additional (comma-separated) source codes.
+    AIRTABLE_COLUMN_OTS_URL - The column that will contain the OneTimeSecret URL.
+    AIRTABLE_GET_RECORDS_FORMULA - The formula to use when retrieving records from Airtable.
+        Formula reference: https://support.airtable.com/v1/docs/formula-field-reference
+"""
+settings = get_secret("ak-partner-rsvp")
+
+# Airtable column names
+COLUMN_ORG_NAME = settings["AIRTABLE_COLUMN_ORG_NAME"]
+COLUMN_SOURCE_CODE = settings["AIRTABLE_COLUMN_SOURCE_CODE"]
+COLUMN_ADDITIONAL_CODES = settings["AIRTABLE_COLUMN_ADDITIONAL_CODES"]
+COLUMN_OTS_URL = settings["AIRTABLE_COLUMN_OTS_URL"]
+
+# OneTimeSecret API URL
+OTS_DEFAULT_URI = "https://us.onetimesecret.com/api/v2/"
+
+
+class OneTimeSecret(object):
+    """
+    A class to interact with the OneTimeSecret API. Leverages the Parsons
+    APIConnector class.
+
+    For more information, see the `Onetime Secret API documentation
+    <https://docs.onetimesecret.com/en/rest-api/>`_.
+    """
+
+    def __init__(self):
+        self.client = APIConnector(OTS_DEFAULT_URI)
+        self.client.headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def create_secret(self, keys, passphrase=None, ttl=259200) -> Table:
+        data = {
+            "secret": {
+                "secret": keys,
+                "passphrase": passphrase,
+                "ttl": ttl,     # Defaults to 72 hours.
+            },
+        }
+        response = self.client.post_request(url="secret/conceal", json=data)
+        return (
+            f"https://us.onetimesecret.com/secret/{response['record']['secret']['key']}"
+        )
+
+
+def create_onetimesecret(onetimesecret, partner, passphrase=None, ttl=259200):
+    logger.info(f"Creating export keys and Onetime Secret for {partner[COLUMN_ORG_NAME]}...")
+
+    additional_codes = partner[COLUMN_ADDITIONAL_CODES] or ""
+    prefix = (
+        datetime.now().strftime("%Y%m%d")
+        + f".{settings['MAX_AGE']}.{partner[COLUMN_SOURCE_CODE]}{additional_codes}.{settings['EVENT_CAMPAIGN_ID']}.full."
+    )
+
+    key = hashlib.sha256()
+    key.update(("%s%s" % (prefix, settings["KEY_HASH_SECRET"])).encode("utf-8"))
+
+    keys = f"""
+Your download key:
+
+{prefix}{key.hexdigest()}
+"""
+
+    return onetimesecret.create_secret(keys, passphrase, ttl)
+
+
+def main(args):
+    airtable = Airtable(
+        settings["AIRTABLE_BASE_KEY"],
+        settings["AIRTABLE_TABLE"],
+        personal_access_token=settings["AIRTABLE_PAT"],
+    )
+    onetimesecret = OneTimeSecret()
+
+    partners = airtable.get_records(
+        fields=[COLUMN_ORG_NAME, COLUMN_SOURCE_CODE, COLUMN_ADDITIONAL_CODES],
+        formula=(settings["AIRTABLE_GET_RECORDS_FORMULA"] or f"{{{COLUMN_OTS_URL}}}=''"),
+    )
+
+    if partners.num_rows:
+        logger.info(f"Found {partners.num_rows} partners to update in Airtable")
+
+        partners.add_column(
+            "onetimesecret url",
+            lambda rec: create_onetimesecret(
+                onetimesecret, rec, passphrase=rec[COLUMN_SOURCE_CODE], ttl=259200
+            ),
+        )
+
+        # This will run the create_onetimesecret() function for each partner.
+        partners.materialize()
+
+        # Remove columns that we don't want to sync back to Airtable.
+        partners.remove_column("createdTime", COLUMN_ORG_NAME, COLUMN_SOURCE_CODE, COLUMN_ADDITIONAL_CODES)
+
+        logger.info("Updating Airtable...")
+        airtable.update_records(partners)
+        logger.info("Done")
+
+
+if __name__ == "__main__":
+    run_from_cli(main, DESCRIPTION, ARG_DEFINITIONS, REQUIRED_ARGS)

--- a/gen_secrets_for_airtable.py
+++ b/gen_secrets_for_airtable.py
@@ -1,13 +1,9 @@
 from datetime import datetime
 import hashlib
 import logging
-import os
 
 from pywell.secrets_manager import get_secret
 from pywell.entry_points import run_from_cli
-
-# MUST be above all parsons imports to avoid full parsons dependencies
-os.environ["PARSONS_SKIP_IMPORT_ALL"] = "1"
 
 from parsons.etl.table import Table  # noqa: E402
 from parsons.utilities.api_connector import APIConnector  # noqa: E402

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ psycopg2-binary==2.9.10
 
 botocore==1.34.22
 boto3==1.34.22
+
+# This is only needed for the gen_secrets_for_airtable.py script.
+parsons[airtable]==5.1.0


### PR DESCRIPTION
This PR adds a script that gets a list of partners from Airtable, generates an export key for each, creates a Onetime Secret link for each key, and then saves the links back to the Airtable base.

Updates to the README are also included.
